### PR TITLE
Prevent List and Dict fields from trying to iterate over None value; return default instead

### DIFF
--- a/remoteobjects/fields.py
+++ b/remoteobjects/fields.py
@@ -267,7 +267,7 @@ class List(Field):
         timestamps, `fld` would be a `Datetime` instance.
 
         """
-        super(List, self).__init__(default=[], **kwargs)
+        super(List, self).__init__(**kwargs)
         self.fld = fld
 
     def install(self, attrname, cls):
@@ -282,7 +282,7 @@ class List(Field):
         if value is None:
             if callable(self.default):
                 return self.default()
-            return self.default
+            return self.default or []
         return [self.fld.decode(v) for v in value]
 
     def encode(self, value):
@@ -300,10 +300,6 @@ class Dict(List):
 
     """
 
-    def __init__(self, **kwargs):
-        """Sets the default to an empty dictionary."""
-        super(Dict, self).__init__(default={}, **kwargs)
-
     def decode(self, value):
         """Decodes the dictionary value (a dictionary with dictionary values
         for values) into a `DataObject` attribute (a dictionary with
@@ -311,7 +307,7 @@ class Dict(List):
         if value is None:
             if callable(self.default):
                 return self.default()
-            return self.default
+            return self.default or {}
         return dict((k, self.fld.decode(v)) for k, v in value.iteritems())
 
     def encode(self, value):

--- a/tests/test_dataobject.py
+++ b/tests/test_dataobject.py
@@ -263,6 +263,27 @@ class TestDataObjects(unittest.TestCase):
             ],
         }, 'Parentish dict has proper contents')
 
+        p = Parentish.from_dict({
+            'name': 'the parent',
+            'children': None
+        })
+
+        self.assertEquals(p.children, [])
+
+    def test_complex_dict(self):
+
+        class Thing(self.cls):
+            name     = fields.Field()
+            attributes = fields.Dict(fields.Field())
+
+        t = Thing.from_dict({
+            'name': 'the thing',
+            'attributes': None,
+        })
+
+        self.assertEquals(t.attributes, {})
+
+
     def test_self_reference(self):
 
         class Reflexive(self.cls):


### PR DESCRIPTION
This is the same fix as pull #4 - just adds tests and avoids using mutable default function arguments.

This has the effect that a List/Dict field will never return None as its decoded value; None will always be transformed into []/{}. Seems fine to me? Easier for handling code to be able to assume that the value of a  List/Dict field will always be a list/dict.
